### PR TITLE
ci: declare env variables for testing profile picture uploads

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,6 +6,11 @@ on:
   pull_request: 
     branches: [main, dev]
 
+env:
+  TEST_CLOUDINARY_CLOUD_NAME: ${{ secrets.TEST_CLOUDINARY_CLOUD_NAME }}
+  TEST_CLOUDINARY_API_KEY: ${{ secrets.TEST_CLOUDINARY_API_KEY }}
+  TEST_CLOUDINARY_API_SECRET: ${{ secrets.TEST_CLOUDINARY_API_SECRET }}
+
 jobs:
   simple_deployment_pipeline:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
This PR adds env variables for `/accounts/upload-profile-picture` tests. 
Fixes failing pipeline workflow.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test
- [ ] linter passes
- [ ] format check passes