### PR TITLE
ci: use github env and secrets in workflow

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -10,6 +10,18 @@ jobs:
   simple_deployment_pipeline:
     runs-on: ubuntu-20.04
     environment: Pre-deployment
+    env:
+      PORT: 8000
+      NAME: Study Buddy
+      APP_ENV: development
+      APP_FRONTEND_DOMAIN: localhost:3000
+      DATABASE_URL: mongodb://localhost:27017/study-buddy
+      TEST_DATABASE_URL: mongodb://localhost:27017/study-buddy-test
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+      JWT_EXPIRY: ${{ secrets.JWT_EXPIRY }}
+      TEST_CLOUDINARY_CLOUD_NAME: ${{ secrets.TEST_CLOUDINARY_CLOUD_NAME }}
+      TEST_CLOUDINARY_API_KEY: ${{ secrets.TEST_CLOUDINARY_API_KEY }}
+      TEST_CLOUDINARY_API_SECRET: ${{ secrets.TEST_CLOUDINARY_API_SECRET }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -17,29 +29,11 @@ jobs:
           node-version: "16"
       - name: Install dependencies
         run: npm install
+      - name: Test env
+        run: "echo testing env: $JWT_SECRET"
       - name: Check code style
         run: npm run format:check
       - name: Lint code base
         run: npm run lint
-      - name: Set up env variables
-        run: |
-          echo "JWT_SECRET=$JWT_SECRET" >> $GITHUB_ENV
-          echo "JWT_EXPIRY=$JWT_EXPIRY" >> $GITHUB_ENV
-          echo "TEST_CLOUDINARY_CLOUD_NAME=$TEST_CLOUDINARY_CLOUD_NAME" >> $GITHUB_ENV
-          echo "TEST_CLOUDINARY_API_KEY=$TEST_CLOUDINARY_API_KEY" >> $GITHUB_ENV
-          echo "TEST_CLOUDINARY_API_SECRET=$TEST_CLOUDINARY_API_SECRET" >> $GITHUB_ENV
-        env:
-          PORT: 8000
-          NAME: Study Buddy
-          APP_ENV: development
-          APP_FRONTEND_DOMAIN: localhost:3000
-          DATABASE_URL: mongodb://localhost:27017/study-buddy
-          TEST_DATABASE_URL: mongodb://localhost:27017/study-buddy-test
-          JWT_SECRET: ${{ secrets.JWT_SECRET }}
-          JWT_EXPIRY: ${{ secrets.JWT_EXPIRY }}
-          TEST_CLOUDINARY_CLOUD_NAME: ${{ secrets.TEST_CLOUDINARY_CLOUD_NAME }}
-          TEST_CLOUDINARY_API_KEY: ${{ secrets.TEST_CLOUDINARY_API_KEY }}
-          TEST_CLOUDINARY_API_SECRET: ${{ secrets.TEST_CLOUDINARY_API_SECRET }}
-
       - name: Run tests
         run: npm run test

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -33,5 +33,9 @@ jobs:
           echo "TEST_CLOUDINARY_CLOUD_NAME=${{ secrets.TEST_CLOUDINARY_CLOUD_NAME }}" >> $GITHUB_ENV
           echo "TEST_CLOUDINARY_API_KEY=${{ secrets.TEST_CLOUDINARY_API_KEY }}" >> $GITHUB_ENV
           echo "TEST_CLOUDINARY_API_SECRET=${{ secrets.TEST_CLOUDINARY_API_SECRET }}" >> $GITHUB_ENV
+      - name: Print environment variables
+        run: |
+          echo "JWT_SECRET: $JWT_SECRET"
+          echo "JWT_KEY: $JWT_KEY"
       - name: Run tests
         run: npm run test

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,19 +6,6 @@ on:
   pull_request: 
     branches: [main, dev]
 
-env:
-  PORT: 8000
-  NAME: Study Buddy
-  APP_ENV: development
-  APP_FRONTEND_DOMAIN: localhost:3000
-  DATABASE_URL: mongodb://localhost:27017/study-buddy
-  TEST_DATABASE_URL: mongodb://localhost:27017/study-buddy-test
-  JWT_SECRET: ${{ secrets.JWT_SECRET }}
-  JWT_EXPIRY: ${{ secrets.JWT_EXPIRY }}
-  TEST_CLOUDINARY_CLOUD_NAME: ${{ secrets.TEST_CLOUDINARY_CLOUD_NAME }}
-  TEST_CLOUDINARY_API_KEY: ${{ secrets.TEST_CLOUDINARY_API_KEY }}
-  TEST_CLOUDINARY_API_SECRET: ${{ secrets.TEST_CLOUDINARY_API_SECRET }}
-
 jobs:
   simple_deployment_pipeline:
     runs-on: ubuntu-20.04
@@ -34,9 +21,25 @@ jobs:
         run: npm run format:check
       - name: Lint code base
         run: npm run lint
-      - name: Print environment variables
+      - name: Set up env variables
         run: |
-          printenv
-          echo "Github token: ${{ secrets.GITHUB_TOKEN }}"
+          echo "JWT_SECRET=$JWT_SECRET" >> $GITHUB_ENV
+          echo "JWT_EXPIRY=$JWT_EXPIRY" >> $GITHUB_ENV
+          echo "TEST_CLOUDINARY_CLOUD_NAME=$TEST_CLOUDINARY_CLOUD_NAME" >> $GITHUB_ENV
+          echo "TEST_CLOUDINARY_API_KEY=$TEST_CLOUDINARY_API_KEY" >> $GITHUB_ENV
+          echo "TEST_CLOUDINARY_API_SECRET=$TEST_CLOUDINARY_API_SECRET" >> $GITHUB_ENV
+        env:
+          PORT: 8000
+          NAME: Study Buddy
+          APP_ENV: development
+          APP_FRONTEND_DOMAIN: localhost:3000
+          DATABASE_URL: mongodb://localhost:27017/study-buddy
+          TEST_DATABASE_URL: mongodb://localhost:27017/study-buddy-test
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          JWT_EXPIRY: ${{ secrets.JWT_EXPIRY }}
+          TEST_CLOUDINARY_CLOUD_NAME: ${{ secrets.TEST_CLOUDINARY_CLOUD_NAME }}
+          TEST_CLOUDINARY_API_KEY: ${{ secrets.TEST_CLOUDINARY_API_KEY }}
+          TEST_CLOUDINARY_API_SECRET: ${{ secrets.TEST_CLOUDINARY_API_SECRET }}
+
       - name: Run tests
         run: npm run test

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: "16"
       - name: Install dependencies
         run: npm install
       - name: Check code style
@@ -22,16 +22,16 @@ jobs:
         run: npm run lint
       - name: Set up environment variables
         run: |
-          echo 'PORT=8000' >> '$GITHUB_ENV'
-          echo 'NAME=Study Buddy' >> '$GITHUB_ENV'
-          echo 'APP_ENV=development' >> '$GITHUB_ENV'
-          echo 'APP_FRONTEND_DOMAIN=localhost:3000' >> '$GITHUB_ENV'
-          echo 'DATABASE_URL=mongodb://localhost:27017/study-buddy' >> '$GITHUB_ENV'
-          echo 'TEST_DATABASE_URL=mongodb://localhost:27017/study-buddy-test' >> '$GITHUB_ENV'
-          echo 'JWT_SECRET=${{ secrets.JWT_SECRET }}' >> '$GITHUB_ENV'
-          echo 'JWT_EXPIRY=${{ secrets.JWT_EXPIRY }}' >> '$GITHUB_ENV'
-          echo 'TEST_CLOUDINARY_CLOUD_NAME=${{ secrets.TEST_CLOUDINARY_CLOUD_NAME }}' >> '$GITHUB_ENV'
-          echo 'TEST_CLOUDINARY_API_KEY=${{ secrets.TEST_CLOUDINARY_API_KEY }}' >> '$GITHUB_ENV'
-          echo 'TEST_CLOUDINARY_API_SECRET=${{ secrets.TEST_CLOUDINARY_API_SECRET }}' >> '$GITHUB_ENV'
+          echo "PORT=8000" >> "$GITHUB_ENV"
+          echo "NAME=Study Buddy" >> "$GITHUB_ENV"
+          echo "APP_ENV=development" >> "$GITHUB_ENV"
+          echo "APP_FRONTEND_DOMAIN=localhost:3000" >> "$GITHUB_ENV"
+          echo "DATABASE_URL=mongodb://localhost:27017/study-buddy" >> "$GITHUB_ENV"
+          echo "TEST_DATABASE_URL=mongodb://localhost:27017/study-buddy-test" >> "$GITHUB_ENV"
+          echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> "$GITHUB_ENV"
+          echo "JWT_EXPIRY=${{ secrets.JWT_EXPIRY }}" >> "$GITHUB_ENV"
+          echo "TEST_CLOUDINARY_CLOUD_NAME=${{ secrets.TEST_CLOUDINARY_CLOUD_NAME }}" >> "$GITHUB_ENV"
+          echo "TEST_CLOUDINARY_API_KEY=${{ secrets.TEST_CLOUDINARY_API_KEY }}" >> "$GITHUB_ENV"
+          echo "TEST_CLOUDINARY_API_SECRET=${{ secrets.TEST_CLOUDINARY_API_SECRET }}" >> "$GITHUB_ENV"
       - name: Run tests
         run: npm run test

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,11 +6,6 @@ on:
   pull_request: 
     branches: [main, dev]
 
-env:
-  TEST_CLOUDINARY_CLOUD_NAME: ${{ secrets.TEST_CLOUDINARY_CLOUD_NAME }}
-  TEST_CLOUDINARY_API_KEY: ${{ secrets.TEST_CLOUDINARY_API_KEY }}
-  TEST_CLOUDINARY_API_SECRET: ${{ secrets.TEST_CLOUDINARY_API_SECRET }}
-
 jobs:
   simple_deployment_pipeline:
     runs-on: ubuntu-20.04
@@ -25,7 +20,18 @@ jobs:
         run: npm run format:check
       - name: Lint code base
         run: npm run lint
-      - name: Prepare .env
-        run: cp example.env .env
+      - name: Set up environment variables
+        run: |
+          echo 'PORT=8000' >> '$GITHUB_ENV'
+          echo 'NAME=Study Buddy' >> '$GITHUB_ENV'
+          echo 'APP_ENV=development' >> '$GITHUB_ENV'
+          echo 'APP_FRONTEND_DOMAIN=localhost:3000' >> '$GITHUB_ENV'
+          echo 'DATABASE_URL=mongodb://localhost:27017/study-buddy' >> '$GITHUB_ENV'
+          echo 'TEST_DATABASE_URL=mongodb://localhost:27017/study-buddy-test' >> '$GITHUB_ENV'
+          echo 'JWT_SECRET=${{ secrets.JWT_SECRET }}' >> '$GITHUB_ENV'
+          echo 'JWT_EXPIRY=${{ secrets.JWT_EXPIRY }}' >> '$GITHUB_ENV'
+          echo 'TEST_CLOUDINARY_CLOUD_NAME=${{ secrets.TEST_CLOUDINARY_CLOUD_NAME }}' >> '$GITHUB_ENV'
+          echo 'TEST_CLOUDINARY_API_KEY=${{ secrets.TEST_CLOUDINARY_API_KEY }}' >> '$GITHUB_ENV'
+          echo 'TEST_CLOUDINARY_API_SECRET=${{ secrets.TEST_CLOUDINARY_API_SECRET }}' >> '$GITHUB_ENV'
       - name: Run tests
         run: npm run test

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -33,9 +33,7 @@ jobs:
           echo "TEST_CLOUDINARY_CLOUD_NAME=${{ secrets.TEST_CLOUDINARY_CLOUD_NAME }}" >> $GITHUB_ENV
           echo "TEST_CLOUDINARY_API_KEY=${{ secrets.TEST_CLOUDINARY_API_KEY }}" >> $GITHUB_ENV
           echo "TEST_CLOUDINARY_API_SECRET=${{ secrets.TEST_CLOUDINARY_API_SECRET }}" >> $GITHUB_ENV
-      - name: Print environment variables
-        run: |
-          echo "JWT_SECRET: $JWT_SECRET"
+          echo $JWT_SECRET
           echo "JWT_KEY: $JWT_KEY"
       - name: Run tests
         run: npm run test

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   simple_deployment_pipeline:
     runs-on: ubuntu-20.04
+    environment: Pre-deployment
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -33,7 +34,8 @@ jobs:
           echo "TEST_CLOUDINARY_CLOUD_NAME=${{ secrets.TEST_CLOUDINARY_CLOUD_NAME }}" >> $GITHUB_ENV
           echo "TEST_CLOUDINARY_API_KEY=${{ secrets.TEST_CLOUDINARY_API_KEY }}" >> $GITHUB_ENV
           echo "TEST_CLOUDINARY_API_SECRET=${{ secrets.TEST_CLOUDINARY_API_SECRET }}" >> $GITHUB_ENV
-          echo $JWT_SECRET
+
+          echo "jwt-secret: $JWT_SECRET"
           echo "JWT_KEY: $JWT_KEY"
       - name: Run tests
         run: npm run test

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -22,16 +22,16 @@ jobs:
         run: npm run lint
       - name: Set up environment variables
         run: |
-          echo "PORT=8000" >> "$GITHUB_ENV"
-          echo "NAME=Study Buddy" >> "$GITHUB_ENV"
-          echo "APP_ENV=development" >> "$GITHUB_ENV"
-          echo "APP_FRONTEND_DOMAIN=localhost:3000" >> "$GITHUB_ENV"
-          echo "DATABASE_URL=mongodb://localhost:27017/study-buddy" >> "$GITHUB_ENV"
-          echo "TEST_DATABASE_URL=mongodb://localhost:27017/study-buddy-test" >> "$GITHUB_ENV"
-          echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> "$GITHUB_ENV"
-          echo "JWT_EXPIRY=${{ secrets.JWT_EXPIRY }}" >> "$GITHUB_ENV"
-          echo "TEST_CLOUDINARY_CLOUD_NAME=${{ secrets.TEST_CLOUDINARY_CLOUD_NAME }}" >> "$GITHUB_ENV"
-          echo "TEST_CLOUDINARY_API_KEY=${{ secrets.TEST_CLOUDINARY_API_KEY }}" >> "$GITHUB_ENV"
-          echo "TEST_CLOUDINARY_API_SECRET=${{ secrets.TEST_CLOUDINARY_API_SECRET }}" >> "$GITHUB_ENV"
+          echo "PORT=8000" >> $GITHUB_ENV
+          echo "NAME=Study Buddy" >> $GITHUB_ENV
+          echo "APP_ENV=development" >> $GITHUB_ENV
+          echo "APP_FRONTEND_DOMAIN=localhost:3000" >> $GITHUB_ENV
+          echo "DATABASE_URL=mongodb://localhost:27017/study-buddy" >> $GITHUB_ENV
+          echo "TEST_DATABASE_URL=mongodb://localhost:27017/study-buddy-test" >> $GITHUB_ENV
+          echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> $GITHUB_ENV
+          echo "JWT_EXPIRY=${{ secrets.JWT_EXPIRY }}" >> $GITHUB_ENV
+          echo "TEST_CLOUDINARY_CLOUD_NAME=${{ secrets.TEST_CLOUDINARY_CLOUD_NAME }}" >> $GITHUB_ENV
+          echo "TEST_CLOUDINARY_API_KEY=${{ secrets.TEST_CLOUDINARY_API_KEY }}" >> $GITHUB_ENV
+          echo "TEST_CLOUDINARY_API_SECRET=${{ secrets.TEST_CLOUDINARY_API_SECRET }}" >> $GITHUB_ENV
       - name: Run tests
         run: npm run test

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,6 +6,19 @@ on:
   pull_request: 
     branches: [main, dev]
 
+env:
+  PORT: 8000
+  NAME: Study Buddy
+  APP_ENV: development
+  APP_FRONTEND_DOMAIN: localhost:3000
+  DATABASE_URL: mongodb://localhost:27017/study-buddy
+  TEST_DATABASE_URL: mongodb://localhost:27017/study-buddy-test
+  JWT_SECRET: ${{ secrets.JWT_SECRET }}
+  JWT_EXPIRY: ${{ secrets.JWT_EXPIRY }}
+  TEST_CLOUDINARY_CLOUD_NAME: ${{ secrets.TEST_CLOUDINARY_CLOUD_NAME }}
+  TEST_CLOUDINARY_API_KEY: ${{ secrets.TEST_CLOUDINARY_API_KEY }}
+  TEST_CLOUDINARY_API_SECRET: ${{ secrets.TEST_CLOUDINARY_API_SECRET }}
+
 jobs:
   simple_deployment_pipeline:
     runs-on: ubuntu-20.04
@@ -21,21 +34,9 @@ jobs:
         run: npm run format:check
       - name: Lint code base
         run: npm run lint
-      - name: Set up environment variables
+      - name: Print environment variables
         run: |
-          echo "PORT=8000" >> $GITHUB_ENV
-          echo "NAME=Study Buddy" >> $GITHUB_ENV
-          echo "APP_ENV=development" >> $GITHUB_ENV
-          echo "APP_FRONTEND_DOMAIN=localhost:3000" >> $GITHUB_ENV
-          echo "DATABASE_URL=mongodb://localhost:27017/study-buddy" >> $GITHUB_ENV
-          echo "TEST_DATABASE_URL=mongodb://localhost:27017/study-buddy-test" >> $GITHUB_ENV
-          echo "JWT_SECRET=${{ secrets.JWT_SECRET }}" >> $GITHUB_ENV
-          echo "JWT_EXPIRY=${{ secrets.JWT_EXPIRY }}" >> $GITHUB_ENV
-          echo "TEST_CLOUDINARY_CLOUD_NAME=${{ secrets.TEST_CLOUDINARY_CLOUD_NAME }}" >> $GITHUB_ENV
-          echo "TEST_CLOUDINARY_API_KEY=${{ secrets.TEST_CLOUDINARY_API_KEY }}" >> $GITHUB_ENV
-          echo "TEST_CLOUDINARY_API_SECRET=${{ secrets.TEST_CLOUDINARY_API_SECRET }}" >> $GITHUB_ENV
-
-          echo "jwt-secret: $JWT_SECRET"
-          echo "JWT_KEY: $JWT_KEY"
+          printenv
+          echo "Github token: ${{ secrets.GITHUB_TOKEN }}"
       - name: Run tests
         run: npm run test


### PR DESCRIPTION
This PR...

## Changes
- use GitHub env and secrets in workflow instead of copying example env.

## Checklist

- [ ] tested locally
- [ ] added new dependencies
- [ ] updated the Swagger API docs
- [ ] updated the Postman collection
- [ ] added a test
- [ ] linter passes
- [ ] format check passes

Fixes #