### PR TITLE
fix: update accounts queries

### DIFF
--- a/src/accounts/__tests__/accounts.students.test.js
+++ b/src/accounts/__tests__/accounts.students.test.js
@@ -22,19 +22,30 @@ beforeAll(async () => {
 });
 
 describe('GET requests', () => {
-  it('to /accounts returns student accounts', async () => {
+  it('to /accounts returns accounts', async () => {
     const response = await api.get('/accounts').expect(200);
+
+    const accountTypes = response.body.data.map(
+      (accounts) => accounts.accountType
+    );
+
+    expect(accountTypes).toContain('Student');
+    expect(accountTypes).toContain('Mentor');
+  });
+
+  it('to /accounts?category=Student returns student accounts', async () => {
+    const response = await api.get('/accounts?category=Student').expect(200);
 
     response.body.data.forEach(({ accountType }) => {
       expect(accountType).toBe('Student');
     });
   });
 
-  it('to /accounts?category=Student returns student accounts', async () => {
-    const response = await api.get('/accounts').expect(200);
+  it('to /accounts?category=Mentor returns mentor accounts', async () => {
+    const response = await api.get('/accounts?category=Mentor').expect(200);
 
     response.body.data.forEach(({ accountType }) => {
-      expect(accountType).toBe('Student');
+      expect(accountType).toBe('Mentor');
     });
   });
 });

--- a/src/accounts/accountsService.js
+++ b/src/accounts/accountsService.js
@@ -44,8 +44,10 @@ async function getMentors() {
 }
 
 async function getAccounts(filters) {
-  const accountType = ACCOUNT_TYPES[filters.category.toUpperCase()];
-  const accounts = await Account.find({ accountType }).populate('owner');
+  const accountType = filters.category
+    ? { accountType: ACCOUNT_TYPES[filters.category.toUpperCase()] }
+    : {};
+  const accounts = await Account.find(accountType).populate('owner');
 
   return accounts;
 }

--- a/src/accounts/accountsValidator.js
+++ b/src/accounts/accountsValidator.js
@@ -3,8 +3,8 @@ const { ACCOUNT_TYPES, REGEX_PATTERNS, TRACKS } = require('../../constant');
 
 const getAccountsValidator = Joi.object({
   category: Joi.string()
-    .valid(...Object.values(ACCOUNT_TYPES))
-    .default(ACCOUNT_TYPES.STUDENT),
+    .optional()
+    .valid(...Object.values(ACCOUNT_TYPES)),
 });
 
 const passwordValidator = Joi.object({

--- a/src/docs/endpoints.yaml
+++ b/src/docs/endpoints.yaml
@@ -119,7 +119,6 @@ paths:
           name: category
           schema:
             type: string
-            default: Student
           description: The category of Accounts to return
       responses:
         '200':


### PR DESCRIPTION
This PR...

removes "Students" as the default category when fetching accounts.

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [x] updated the Swagger API docs
- [ ] updated the Postman collection
- [ ] added a test
- [x] linter passes
- [x] format check passes
