### PR TITLE
chore: include profile picture field in author object

### DIFF
--- a/src/answers/__tests__/answer.test.js
+++ b/src/answers/__tests__/answer.test.js
@@ -77,7 +77,12 @@ describe('Creating answer to a question', () => {
     expect(response.body.data).toHaveProperty('upvotedBy');
     expect(response.body.data).toHaveProperty('downvotes');
     expect(response.body.data).toHaveProperty('downvotedBy');
-    expect(response.body.data).toHaveProperty('author');
+    expect(response.body.data.author).toEqual({
+      _id: user._id,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      profilePicture: expect.any(String),
+    });
     expect(response.body.data.author).toHaveProperty('_id', user._id);
     expect(response.body.data).toHaveProperty('question', question._id);
   });

--- a/src/answers/answersService.js
+++ b/src/answers/answersService.js
@@ -2,7 +2,11 @@ const Answer = require('../../model/answer');
 const Question = require('../../model/question');
 
 const getAnswer = async (id) => {
-  const answers = await Answer.find({ id }).populate('author');
+  const answers = await Answer.find({ id }).populate('author', {
+    firstName: 1,
+    lastName: 1,
+    profilePicture: 1,
+  });
 
   return answers;
 };
@@ -10,7 +14,11 @@ const getAnswer = async (id) => {
 const getAnswers = async (questionId) => {
   const answers = await Answer.find({
     question: questionId,
-  }).populate('author');
+  }).populate('author', {
+    firstName: 1,
+    lastName: 1,
+    profilePicture: 1,
+  });
 
   return answers;
 };
@@ -24,7 +32,11 @@ const createAnswer = async (answer) => {
 
   await question.save();
   await newAnswer.save();
-  await newAnswer.populate('author');
+  await newAnswer.populate('author', {
+    firstName: 1,
+    lastName: 1,
+    profilePicture: 1,
+  });
 
   return newAnswer;
 };
@@ -38,13 +50,21 @@ const updateAnswer = async (id, { content }) => {
       runValidators: true,
       context: 'query',
     }
-  ).populate('author');
+  ).populate('author', {
+    firstName: 1,
+    lastName: 1,
+    profilePicture: 1,
+  });
 
   return updatedAnswer;
 };
 
 const upvoteAnswer = async ({ id, userId }) => {
-  const answer = await Answer.findById(id).populate('author');
+  const answer = await Answer.findById(id).populate('author', {
+    firstName: 1,
+    lastName: 1,
+    profilePicture: 1,
+  });
   if (!answer) {
     return false;
   }
@@ -79,7 +99,11 @@ const upvoteAnswer = async ({ id, userId }) => {
 };
 
 const downvoteAnswer = async ({ id, userId }) => {
-  const answer = await Answer.findById(id).populate('author');
+  const answer = await Answer.findById(id).populate('author', {
+    firstName: 1,
+    lastName: 1,
+    profilePicture: 1,
+  });
   if (!answer) {
     return false;
   }

--- a/src/comments/__tests__/comments.test.js
+++ b/src/comments/__tests__/comments.test.js
@@ -67,7 +67,12 @@ describe('Creating comment', () => {
     expect(response.body.data).toHaveProperty('upvotedBy');
     expect(response.body.data).toHaveProperty('downvotes');
     expect(response.body.data).toHaveProperty('downvotedBy');
-    expect(response.body.data).toHaveProperty('author');
+    expect(response.body.data.author).toEqual({
+      _id: user._id,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      profilePicture: expect.any(String),
+    });
     expect(response.body.data.author).toHaveProperty('_id', user._id);
     expect(response.body.data).toHaveProperty('post', post._id);
   });
@@ -127,6 +132,12 @@ describe('Modifying a comment', () => {
       .expect('Content-Type', /application\/json/);
 
     expect(response.body.data).toHaveProperty('content', content);
+    expect(response.body.data.author).toEqual({
+      _id: user._id,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      profilePicture: expect.any(String),
+    });
   });
 });
 
@@ -155,6 +166,12 @@ describe('Upvoting a comment', () => {
 
     expect(response.body.data.upvotes).toBe(comment.upvotes + 1);
     expect(response.body.data.upvotedBy).toContain(user._id);
+    expect(response.body.data.author).toEqual({
+      _id: expect.any(String),
+      firstName: expect.any(String),
+      lastName: expect.any(String),
+      profilePicture: expect.any(String),
+    });
 
     user = users[1];
     await login(user);
@@ -167,6 +184,12 @@ describe('Upvoting a comment', () => {
 
     expect(res.body.data.upvotes).toBe(comment.upvotes + 2);
     expect(res.body.data.upvotedBy).toContain(user._id);
+    expect(res.body.data.author).toEqual({
+      _id: expect.any(String),
+      firstName: expect.any(String),
+      lastName: expect.any(String),
+      profilePicture: expect.any(String),
+    });
   });
 
   it('if a user has previously upvoted removes the vote', async () => {
@@ -185,6 +208,12 @@ describe('Upvoting a comment', () => {
 
     expect(response.body.data.upvotes).toBe(comment.upvotes - 1);
     expect(response.body.data.upvotedBy).not.toContain(user._id);
+    expect(response.body.data.author).toEqual({
+      _id: expect.any(String),
+      firstName: expect.any(String),
+      lastName: expect.any(String),
+      profilePicture: expect.any(String),
+    });
   });
 });
 
@@ -210,6 +239,12 @@ describe('Downvoting a comment', () => {
 
     expect(response.body.data.downvotes).toBe(comment.downvotes + 1);
     expect(response.body.data.downvotedBy).toContain(user._id);
+    expect(response.body.data.author).toEqual({
+      _id: expect.any(String),
+      firstName: expect.any(String),
+      lastName: expect.any(String),
+      profilePicture: expect.any(String),
+    });
 
     user = users[1];
     await login(user);
@@ -222,6 +257,12 @@ describe('Downvoting a comment', () => {
 
     expect(res.body.data.downvotes).toBe(comment.downvotes + 2);
     expect(res.body.data.downvotedBy).toContain(user._id);
+    expect(res.body.data.author).toEqual({
+      _id: expect.any(String),
+      firstName: expect.any(String),
+      lastName: expect.any(String),
+      profilePicture: expect.any(String),
+    });
   });
 
   it('if a user has previously downvoted removes the vote', async () => {
@@ -240,6 +281,12 @@ describe('Downvoting a comment', () => {
 
     expect(response.body.data.downvotes).toBe(comment.downvotes - 1);
     expect(response.body.data.downvotedBy).not.toContain(user._id);
+    expect(response.body.data.author).toEqual({
+      _id: expect.any(String),
+      firstName: expect.any(String),
+      lastName: expect.any(String),
+      profilePicture: expect.any(String),
+    });
   });
 });
 

--- a/src/comments/commentsService.js
+++ b/src/comments/commentsService.js
@@ -5,6 +5,7 @@ const getComment = async (id) => {
   const comment = await Comment.findById(id).populate('author', {
     firstName: 1,
     lastName: 1,
+    profilePicture: 1,
   });
 
   return comment;
@@ -16,6 +17,7 @@ const getComments = async (postId) => {
   }).populate('author', {
     firstName: 1,
     lastName: 1,
+    profilePicture: 1,
   });
 
   return comments;
@@ -33,6 +35,7 @@ const createComment = async (comment) => {
   await newComment.populate('author', {
     firstName: 1,
     lastName: 1,
+    profilePicture: 1,
   });
 
   return newComment;
@@ -50,6 +53,7 @@ const updateComment = async (id, { content }) => {
   ).populate('author', {
     firstName: 1,
     lastName: 1,
+    profilePicture: 1,
   });
 
   return updatedComment;
@@ -59,6 +63,7 @@ const upvoteComment = async ({ id, userId }) => {
   const comment = await Comment.findById(id).populate('author', {
     firstName: 1,
     lastName: 1,
+    profilePicture: 1,
   });
   if (!comment) {
     return false;
@@ -91,6 +96,7 @@ const downvoteComment = async ({ id, userId }) => {
   const comment = await Comment.findById(id).populate('author', {
     firstName: 1,
     lastName: 1,
+    profilePicture: 1,
   });
   if (!comment) {
     return false;

--- a/src/posts/__tests__/posts.test.js
+++ b/src/posts/__tests__/posts.test.js
@@ -47,6 +47,7 @@ describe('Creating a post', () => {
         _id: author.toString(),
         firstName: expect.any(String),
         lastName: expect.any(String),
+        profilePicture: expect.any(String),
       }),
       upvotes: 0,
       upvotedBy: [],
@@ -96,6 +97,12 @@ describe('Modifying a post', () => {
       .expect('Content-Type', /application\/json/);
 
     expect(response.body.data).toHaveProperty('content', content);
+    expect(response.body.data.author).toEqual({
+      _id: user._id,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      profilePicture: expect.any(String),
+    });
   });
 });
 
@@ -121,6 +128,14 @@ describe('Upvoting/liking a post', () => {
 
     expect(response.body.data.upvotes).toBe(post.upvotes + 1);
     expect(response.body.data.upvotedBy).toContain(user._id);
+    expect(response.body.data.author).toEqual(
+      expect.objectContaining({
+        _id: expect.any(String),
+        firstName: expect.any(String),
+        lastName: expect.any(String),
+        profilePicture: expect.any(String),
+      })
+    );
 
     user = users[1];
     await login(user);
@@ -133,6 +148,14 @@ describe('Upvoting/liking a post', () => {
 
     expect(res.body.data.upvotes).toBe(post.upvotes + 2);
     expect(res.body.data.upvotedBy).toContain(user._id);
+    expect(res.body.data.author).toEqual(
+      expect.objectContaining({
+        _id: expect.any(String),
+        firstName: expect.any(String),
+        lastName: expect.any(String),
+        profilePicture: expect.any(String),
+      })
+    );
   });
 
   test('if a user has previously upvoted/liked removes the upvote/like', async () => {
@@ -152,6 +175,14 @@ describe('Upvoting/liking a post', () => {
 
     expect(response.body.data.upvotes).toBe(post.upvotes - 1);
     expect(response.body.data.upvotedBy).not.toContain(user._id);
+    expect(response.body.data.author).toEqual(
+      expect.objectContaining({
+        _id: expect.any(String),
+        firstName: expect.any(String),
+        lastName: expect.any(String),
+        profilePicture: expect.any(String),
+      })
+    );
   });
 });
 

--- a/src/posts/postsService.js
+++ b/src/posts/postsService.js
@@ -4,6 +4,7 @@ const getPosts = async ({ query } = {}) => {
   const posts = await Post.find(query).populate('author', {
     firstName: 1,
     lastName: 1,
+    profilePicture: 1,
   });
 
   return posts;
@@ -13,6 +14,7 @@ const getPost = async (postId) => {
   const post = await Post.findById(postId).populate('author', {
     firstName: 1,
     lastName: 1,
+    profilePicture: 1,
   });
 
   return post;
@@ -23,6 +25,7 @@ const createPost = async (post) => {
   await newPost.populate('author', {
     firstName: 1,
     lastName: 1,
+    profilePicture: 1,
   });
   return newPost;
 };
@@ -36,6 +39,7 @@ const updatePost = async ({ postId, post }) => {
   await updatedPost.populate('author', {
     firstName: 1,
     lastName: 1,
+    profilePicture: 1,
   });
 
   return updatedPost;
@@ -46,6 +50,7 @@ const deletePost = async (postId) => {
   await post.populate('author', {
     firstName: 1,
     lastName: 1,
+    profilePicture: 1,
   });
 
   return post;
@@ -60,6 +65,7 @@ const upvotePost = async ({ userId, postId }) => {
   const post = await Post.findById(postId).populate('author', {
     firstName: 1,
     lastName: 1,
+    profilePicture: 1,
   });
   if (!post) {
     return false;

--- a/src/questions/__tests__/questions.test.js
+++ b/src/questions/__tests__/questions.test.js
@@ -62,7 +62,12 @@ describe('Creating a question', () => {
     expect(response.body.data).toHaveProperty('body', body);
     expect(response.body.data).toHaveProperty('upvotes', 0);
     expect(response.body.data).toHaveProperty('downvotes', 0);
-    expect(response.body.data).toHaveProperty('author', user._id);
+    expect(response.body.data.author).toEqual({
+      _id: user._id,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      profilePicture: expect.any(String),
+    });
     expect(response.body.data).toHaveProperty('slug', slug);
   });
 });
@@ -126,6 +131,12 @@ describe('Modifying a question', () => {
     // check response for specific properties
     expect(response.body.data).toHaveProperty('body', body);
     expect(response.body.data).toHaveProperty('slug', slug);
+    expect(response.body.data.author).toEqual({
+      _id: user._id,
+      firstName: user.firstName,
+      lastName: user.lastName,
+      profilePicture: expect.any(String),
+    });
   });
 });
 
@@ -159,6 +170,14 @@ describe('Upvoting a question', () => {
     // check response for specific properties
     expect(response.body.data.upvotes).toBe(questions[0].upvotes + 1);
     expect(response.body.data.upvotedBy).toContain(user._id);
+    expect(response.body.data.author).toEqual(
+      expect.objectContaining({
+        _id: expect.any(String),
+        firstName: expect.any(String),
+        lastName: expect.any(String),
+        profilePicture: expect.any(String),
+      })
+    );
 
     // get questions from DB
     questions = await helper.questionsInDb();
@@ -177,6 +196,14 @@ describe('Upvoting a question', () => {
     // check response2 for specific properties
     expect(response2.body.data.upvotes).toBe(questions[0].upvotes + 1);
     expect(response2.body.data.upvotedBy).toContain(user._id);
+    expect(response2.body.data.author).toEqual(
+      expect.objectContaining({
+        _id: expect.any(String),
+        firstName: expect.any(String),
+        lastName: expect.any(String),
+        profilePicture: expect.any(String),
+      })
+    );
   });
 
   test('if a user has previously upvoted removes the vote', async () => {
@@ -198,6 +225,14 @@ describe('Upvoting a question', () => {
     // check response for specific properties
     expect(response.body.data.upvotes).toBe(questions[0].upvotes - 1);
     expect(response.body.data.upvotedBy).not.toContain(user._id);
+    expect(response.body.data.author).toEqual(
+      expect.objectContaining({
+        _id: expect.any(String),
+        firstName: expect.any(String),
+        lastName: expect.any(String),
+        profilePicture: expect.any(String),
+      })
+    );
   });
 
   test('if a user has previously downvoted removes the downvote', async () => {
@@ -217,6 +252,14 @@ describe('Upvoting a question', () => {
       .expect('Content-Type', /application\/json/);
     expect(res.body.data.downvotes).toBe(questions[0].downvotes + 1);
     expect(res.body.data.downvotedBy).toContain(user._id);
+    expect(res.body.data.author).toEqual(
+      expect.objectContaining({
+        _id: expect.any(String),
+        firstName: expect.any(String),
+        lastName: expect.any(String),
+        profilePicture: expect.any(String),
+      })
+    );
 
     // send a patch request to downvote question
     const response = await api
@@ -230,6 +273,14 @@ describe('Upvoting a question', () => {
     expect(response.body.data.upvotedBy).toContain(user._id);
     expect(response.body.data.downvotes).toBe(questions[0].downvotes);
     expect(response.body.data.downvotedBy).not.toContain(user._id);
+    expect(response.body.data.author).toEqual(
+      expect.objectContaining({
+        _id: expect.any(String),
+        firstName: expect.any(String),
+        lastName: expect.any(String),
+        profilePicture: expect.any(String),
+      })
+    );
   });
 });
 
@@ -263,6 +314,14 @@ describe('Downvoting a question', () => {
     // check response for specific properties
     expect(response.body.data.downvotes).toBe(questions[0].downvotes + 1);
     expect(response.body.data.downvotedBy).toContain(user._id);
+    expect(response.body.data.author).toEqual(
+      expect.objectContaining({
+        _id: expect.any(String),
+        firstName: expect.any(String),
+        lastName: expect.any(String),
+        profilePicture: expect.any(String),
+      })
+    );
 
     // get questions from DB
     questions = await helper.questionsInDb();
@@ -281,6 +340,14 @@ describe('Downvoting a question', () => {
     // check response2 for specific properties
     expect(response2.body.data.downvotes).toBe(questions[0].downvotes + 1);
     expect(response2.body.data.downvotedBy).toContain(user._id);
+    expect(response2.body.data.author).toEqual(
+      expect.objectContaining({
+        _id: expect.any(String),
+        firstName: expect.any(String),
+        lastName: expect.any(String),
+        profilePicture: expect.any(String),
+      })
+    );
   });
 
   test('if a user has previously downvoted removes the vote', async () => {
@@ -302,6 +369,14 @@ describe('Downvoting a question', () => {
     // check response for specific properties
     expect(response.body.data.downvotes).toBe(questions[0].downvotes - 1);
     expect(response.body.data.downvotedBy).not.toContain(user._id);
+    expect(response.body.data.author).toEqual(
+      expect.objectContaining({
+        _id: expect.any(String),
+        firstName: expect.any(String),
+        lastName: expect.any(String),
+        profilePicture: expect.any(String),
+      })
+    );
   });
 
   test('if a user has previously upvoted removes the upvote', async () => {
@@ -321,6 +396,14 @@ describe('Downvoting a question', () => {
       .expect('Content-Type', /application\/json/);
     expect(res.body.data.upvotes).toBe(questions[0].upvotes + 1);
     expect(res.body.data.upvotedBy).toContain(user._id);
+    expect(res.body.data.author).toEqual(
+      expect.objectContaining({
+        _id: expect.any(String),
+        firstName: expect.any(String),
+        lastName: expect.any(String),
+        profilePicture: expect.any(String),
+      })
+    );
 
     // send a patch request to downvote question
     const response = await api
@@ -334,6 +417,14 @@ describe('Downvoting a question', () => {
     expect(response.body.data.downvotedBy).toContain(user._id);
     expect(response.body.data.upvotes).toBe(questions[0].upvotes);
     expect(response.body.data.upvotedBy).not.toContain(user._id);
+    expect(response.body.data.author).toEqual(
+      expect.objectContaining({
+        _id: expect.any(String),
+        firstName: expect.any(String),
+        lastName: expect.any(String),
+        profilePicture: expect.any(String),
+      })
+    );
   });
 });
 

--- a/src/questions/questionsService.js
+++ b/src/questions/questionsService.js
@@ -4,6 +4,7 @@ const getQuestions = async () => {
   const questions = await Question.find({}).populate('author', {
     firstName: 1,
     lastName: 1,
+    profilePicture: 1,
   });
 
   return questions;
@@ -13,6 +14,7 @@ const getQuestion = async (questionId) => {
   const question = await Question.findById(questionId).populate('author', {
     firstName: 1,
     lastName: 1,
+    profilePicture: 1,
   });
 
   return question;
@@ -20,6 +22,11 @@ const getQuestion = async (questionId) => {
 
 const createQuestion = async (question) => {
   const newQuestion = await Question.create(question);
+  await newQuestion.populate('author', {
+    firstName: 1,
+    lastName: 1,
+    profilePicture: 1,
+  });
   return newQuestion;
 };
 
@@ -32,13 +39,24 @@ const updateQuestion = async ({ questionId, question }) => {
       runValidators: true,
       context: 'query',
     }
-  );
+  ).populate('author', {
+    firstName: 1,
+    lastName: 1,
+    profilePicture: 1,
+  });
 
   return updatedQuestion;
 };
 
 const deleteQuestion = async (questionId) => {
-  const question = await Question.findByIdAndDelete(questionId);
+  const question = await Question.findByIdAndDelete(questionId).populate(
+    'author',
+    {
+      firstName: 1,
+      lastName: 1,
+      profilePicture: 1,
+    }
+  );
 
   return question;
 };
@@ -52,6 +70,7 @@ const upvoteQuestion = async ({ userId, questionId }) => {
   const question = await Question.findById(questionId).populate('author', {
     firstName: 1,
     lastName: 1,
+    profilePicture: 1,
   });
   if (!question) {
     return false;
@@ -90,6 +109,7 @@ const downvoteQuestion = async ({ userId, questionId }) => {
   const question = await Question.findById(questionId).populate('author', {
     firstName: 1,
     lastName: 1,
+    profilePicture: 1,
   });
   if (!question) {
     return false;


### PR DESCRIPTION
This PR...

includes `profilePicture` field in the `author` object for `questions`, `answers`, `posts` and `comments`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the Swagger API docs
- [ ] updated the Postman collection
- [x] added a test
- [x] linter passes
- [x] format check passes
