### PR TITLE
bugfix(#191): Bookmarks pagination in wrong order

### DIFF
--- a/src/bookmarks/bookmarksService.js
+++ b/src/bookmarks/bookmarksService.js
@@ -23,7 +23,10 @@ const getBookmarks = async (owner, { query }) => {
         },
       ],
     });
-  const bookmarks = await new apiFeatures(bookmarksQuery, query).paginate();
+  const bookmarks = await new apiFeatures(bookmarksQuery, query)
+    .filter()
+    .sort()
+    .paginate();
   return bookmarks;
 };
 

--- a/src/common/pagination/paginationSchema.js
+++ b/src/common/pagination/paginationSchema.js
@@ -1,10 +1,10 @@
 const Joi = require('joi');
+const searchSchema = require('../search/searchSchema');
 
-const paginationSchema = Joi.object().keys({
+const paginationSchema = searchSchema.keys({
   limit: Joi.number().integer().min(1).max(100).optional(),
   page: Joi.number().integer().min(1).optional(),
   sort: Joi.string().optional(),
-  searchTerm: Joi.string().optional(),
   isPaginated: Joi.boolean().optional(),
 });
 

--- a/src/common/search/searchSchema.js
+++ b/src/common/search/searchSchema.js
@@ -1,0 +1,10 @@
+const Joi = require('joi');
+
+const searchSchema = Joi.object().keys({
+  title: Joi.string().optional(),
+  author: Joi.string().optional(),
+  searchTerm: Joi.string().optional(),
+  tags: Joi.string().optional(),
+});
+
+module.exports = searchSchema;


### PR DESCRIPTION
This PR...

## Changes

- [new: extend pagination schema with keys for search](https://github.com/AltCamp/altcampv1-backend/commit/df2af4830620e355ce7cc91b501b15302427e144)

- [fix: apply sort and filter when fetching bookmarks](https://github.com/AltCamp/altcampv1-backend/commit/be7e98e7476653e618f0539dc3b6d1343ab40164)

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the Swagger API docs
- [x] updated the Postman collection
- [ ] added a test
- [x] linter passes
- [x] format check passes



Fixes #192 