### PR TITLE
new: add method to validate password reset token

### DIFF
--- a/src/accounts/accountsController.js
+++ b/src/accounts/accountsController.js
@@ -1,7 +1,8 @@
-const { RESPONSE_MESSAGE } = require('../../constant');
+const { RESPONSE_MESSAGE, TOKEN_TYPE } = require('../../constant');
 const responseHandler = require('../../utils/responseHandler');
 const accountsService = require('./accountsService');
 const { NotFoundError } = require('../../utils/customError');
+const TokenService = require('../token/tokenService');
 
 async function uploadProfilePicture(req, res, next) {
   try {
@@ -105,6 +106,19 @@ const resetPassword = async (req, res) => {
   new responseHandler(res, reset, 200, RESPONSE_MESSAGE.SUCCESS);
 };
 
+const validatePasswordResetOtp = async (req, res) => {
+  const { requestId, token } = req.body;
+  const data = await TokenService.validateToken({
+    requestId,
+    type: TOKEN_TYPE.PASSWORD_RESET,
+    otp: token,
+  });
+
+  return data
+    ? new responseHandler(res, data, 200, RESPONSE_MESSAGE.SUCCESS)
+    : new responseHandler(res, data, 401, RESPONSE_MESSAGE.UNAUTHORIZED);
+};
+
 module.exports = {
   deleteAccount,
   getAccount,
@@ -115,4 +129,5 @@ module.exports = {
   updatePassword,
   forgotPassword,
   resetPassword,
+  validatePasswordResetOtp,
 };

--- a/src/accounts/accountsValidator.js
+++ b/src/accounts/accountsValidator.js
@@ -99,6 +99,11 @@ const resetPasswordValidator = Joi.object({
   }),
 });
 
+const validateTokenValidator = Joi.object({
+  requestId: resetPasswordValidator.extract('requestId'),
+  token: resetPasswordValidator.extract('token'),
+});
+
 module.exports = {
   deleteAccountValidator,
   getAccountsValidator,
@@ -108,4 +113,5 @@ module.exports = {
   profileValidator,
   forgotPasswordValidator,
   resetPasswordValidator,
+  validateTokenValidator,
 };

--- a/src/accounts/index.js
+++ b/src/accounts/index.js
@@ -11,6 +11,7 @@ const {
   updatePassword,
   forgotPassword,
   resetPassword,
+  validatePasswordResetOtp,
 } = require('./accountsController');
 const {
   getAccountsValidator,
@@ -21,6 +22,7 @@ const {
   passwordValidator,
   forgotPasswordValidator,
   resetPasswordValidator,
+  validateTokenValidator,
 } = require('./accountsValidator');
 const validator = require('../common/validator');
 
@@ -55,6 +57,10 @@ router
 router
   .route('/forgot-password')
   .post(validatorMiddleware(forgotPasswordValidator), forgotPassword);
+
+router
+  .route('/verify-password-reset-otp')
+  .post(validatorMiddleware(validateTokenValidator), validatePasswordResetOtp);
 
 router
   .route('/reset-password')

--- a/src/token/tokenService.js
+++ b/src/token/tokenService.js
@@ -26,5 +26,14 @@ class TokenService {
   static async deleteToken(_id) {
     return await redisClient.del(_id);
   }
+
+  static async validateToken({ requestId, type, otp }) {
+    const key = type + requestId;
+    const tokenObj = await this.getToken(key);
+
+    if (!tokenObj?.token) return false;
+
+    return Number(otp) === tokenObj.token;
+  }
 }
 module.exports = TokenService;


### PR DESCRIPTION
This PR...

- exposes an API (`/accounts/verify-password-reset-otp`) to validate password reset tokens

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the Swagger API docs
- [x] updated the Postman collection
- [ ] added a test
- [x] linter passes
- [x] format check passes