### PR TITLE
new: delete bookmark using "postId"

### DIFF
--- a/src/bookmarks/__tests__/bookmarks.test.js
+++ b/src/bookmarks/__tests__/bookmarks.test.js
@@ -279,20 +279,22 @@ describe('Deleting a bookmark', () => {
     await api
       .delete(`${url}/${_id}`)
       .set('Authorization', `Bearer ${token}`)
-      .expect(401);
+      .expect(404);
   });
 
   test('is successful if user is owner', async () => {
     const bookmarksInDb = await helper.bookmarksInDb();
-    const { _id, owner } = bookmarksInDb[0];
+    const { owner, post } = bookmarksInDb[0];
 
     const user = helper.accountsAsJson.find(
       ({ _id }) => _id === owner.toString()
     );
+    console.log('🚀 ~ file: bookmarks.test.js:292 ~ user:', user);
     await login(user);
 
     await api
-      .delete(`${url}/${_id}`)
+      .delete(`${url}`)
+      .query({ postId: `${post.toString()}` })
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
   });

--- a/src/bookmarks/bookmarksController.js
+++ b/src/bookmarks/bookmarksController.js
@@ -29,8 +29,6 @@ const getAllBookmarks = async (req, res) => {
   new responseHandler(res, data, 200, RESPONSE_MESSAGE.SUCCESS, meta);
 };
 
-<<<<<<< HEAD
-=======
 const deleteBookmark = async (req, res) => {
   const { postId } = req.query;
 
@@ -42,7 +40,6 @@ const deleteBookmark = async (req, res) => {
   new responseHandler(res, deletedBookmark, 200, RESPONSE_MESSAGE.SUCCESS);
 };
 
->>>>>>> c2f0a65 (test: update bookmark-related tests)
 const createBookmark = async (req, res) => {
   const payload = { ...req.body };
   req.query.isPaginated = false;
@@ -87,23 +84,6 @@ const updateBookmark = async (req, res) => {
   if (!updatedBookmark) throw new NotFoundError('Not Found');
 
   new responseHandler(res, updatedBookmark, 200, RESPONSE_MESSAGE.SUCCESS);
-};
-
-const deleteBookmark = async (req, res) => {
-  const bookmarkId = req.params.id;
-
-  const isOwner = await bookmarksService.isBookmarkOwner({
-    userId: req.user._id,
-    bookmarkId,
-  });
-
-  if (!isOwner) throw new UnAuthorizedError('Unauthorized');
-
-  const deleted = await bookmarksService.deleteBookmark(bookmarkId);
-
-  if (!deleted) throw new NotFoundError('Not Found');
-
-  new responseHandler(res, deleted, 200, RESPONSE_MESSAGE.SUCCESS);
 };
 
 const deleteBookmarks = async (req, res) => {

--- a/src/bookmarks/bookmarksController.js
+++ b/src/bookmarks/bookmarksController.js
@@ -29,6 +29,20 @@ const getAllBookmarks = async (req, res) => {
   new responseHandler(res, data, 200, RESPONSE_MESSAGE.SUCCESS, meta);
 };
 
+<<<<<<< HEAD
+=======
+const deleteBookmark = async (req, res) => {
+  const { postId } = req.query;
+
+  const deletedBookmark = await bookmarksService.deleteBookmark({
+    author: req.user._id,
+    postId,
+  });
+
+  new responseHandler(res, deletedBookmark, 200, RESPONSE_MESSAGE.SUCCESS);
+};
+
+>>>>>>> c2f0a65 (test: update bookmark-related tests)
 const createBookmark = async (req, res) => {
   const payload = { ...req.body };
   req.query.isPaginated = false;

--- a/src/bookmarks/bookmarksValidator.js
+++ b/src/bookmarks/bookmarksValidator.js
@@ -31,8 +31,19 @@ const deleteBookmarkValidator = Joi.object({
   }),
 });
 
+class BookmarksValidator {
+  static validateDeleteBookmark() {
+    return Joi.object({
+      postId: Joi.string().required().messages({
+        'string.empty': 'ID of bookmarked post is required',
+        'any.required': 'ID of bookmarked post is required',
+      }),
+    });
+  }
+}
 module.exports = {
   createBookmarkValidator,
   deleteBookmarkValidator,
   updateBookmarkValidator,
+  BookmarksValidator,
 };

--- a/src/bookmarks/index.js
+++ b/src/bookmarks/index.js
@@ -3,8 +3,8 @@ const bookmarks = require('./bookmarksController');
 const { verifyUser } = require('../../middleware/authenticate');
 const {
   createBookmarkValidator,
-  deleteBookmarkValidator,
   updateBookmarkValidator,
+  BookmarksValidator,
 } = require('./bookmarksValidator');
 const validatorMiddleware = require('../../middleware/validator');
 const { paginationSchema, validator } = require('../common');
@@ -21,8 +21,8 @@ router
   )
   .delete(
     limiter(),
-    validatorMiddleware(deleteBookmarkValidator),
-    bookmarks.deleteBookmarks
+    validator.query(BookmarksValidator.validateDeleteBookmark()),
+    bookmarks.deleteBookmark
   );
 
 router
@@ -32,7 +32,6 @@ router
     limiter(),
     validatorMiddleware(updateBookmarkValidator),
     bookmarks.updateBookmark
-  )
-  .delete(bookmarks.deleteBookmark);
+  );
 
 module.exports = router;


### PR DESCRIPTION
This PR...

modifies the API endpoint to delete individual bookmarks. To delete a bookmark, pass the id of the bookmarked content as a query parameter to the API:

 `DELETE` `/bookmarks?postId=id-of-bookmarked-content`

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the Swagger API docs
- [x] updated the Postman collection
- [x] added a test
- [x] linter passes
- [x] format check passes

Fixes #224 