### PR TITLE
Create bookmarks using query parameters

### DIFF
--- a/model/bookmark.js
+++ b/model/bookmark.js
@@ -3,10 +3,6 @@ const { POST_TYPES } = require('../constant');
 
 const bookmarkSchema = new mongoose.Schema(
   {
-    title: {
-      type: String,
-      required: true,
-    },
     postType: {
       type: String,
       required: true,

--- a/src/bookmarks/__tests__/bookmarks.test.js
+++ b/src/bookmarks/__tests__/bookmarks.test.js
@@ -6,7 +6,6 @@ const helper = require('../../../test/testHelper');
 
 const url = '/bookmarks';
 let postType = 'Post';
-const title = 'This is an intriguing thing';
 let token;
 
 beforeAll(async () => {
@@ -38,10 +37,9 @@ describe('Creating a bookmark', () => {
     // send a post request with id of Post
     await api
       .post(url)
-      .send({
-        title,
+      .query({
         postType,
-        postId: _id,
+        postId: _id.toString(),
       })
       .expect(401);
   });
@@ -60,17 +58,15 @@ describe('Creating a bookmark', () => {
     const response = await api
       .post(url)
       .set('Authorization', `Bearer ${token}`)
-      .send({
-        title,
+      .query({
         postType,
-        postId: _id,
+        postId: _id.toString(),
       })
       .expect(201)
       .expect('Content-Type', /application\/json/);
 
     // check response for specific properties
     expect(response.body.data).toHaveProperty('_id');
-    expect(response.body.data).toHaveProperty('title', title);
     expect(response.body.data).toHaveProperty('isRead', false);
     expect(response.body.data.owner).toEqual(
       expect.objectContaining({
@@ -95,7 +91,7 @@ describe('Creating a bookmark', () => {
     );
 
     const answersInDb = await helper.answersInDb();
-    const { _id: postId, content: answerTitle, question } = answersInDb[0];
+    const { _id: postId, question } = answersInDb[0];
 
     const questionsInDb = await helper.questionsInDb();
     const answeredQuestion = questionsInDb.find(
@@ -106,10 +102,9 @@ describe('Creating a bookmark', () => {
     const res = await api
       .post(url)
       .set('Authorization', `Bearer ${token}`)
-      .send({
-        title: answerTitle,
+      .query({
         postType: 'Answer',
-        postId,
+        postId: postId.toString(),
       })
       .expect(201)
       .expect('Content-Type', /application\/json/);
@@ -117,7 +112,6 @@ describe('Creating a bookmark', () => {
     expect(res.body.data.post.question).toEqual(
       expect.objectContaining({
         _id: answeredQuestion._id.toString(),
-        title: answeredQuestion.title,
         slug: answeredQuestion.slug,
       })
     );
@@ -183,7 +177,6 @@ describe('Updating a bookmark', () => {
       .patch(`${url}/${_id}`)
       .set('Authorization', `Bearer ${token}`)
       .send({
-        title: 'Heyyo!',
         isRead: true,
       })
       .expect(401);
@@ -205,19 +198,16 @@ describe('Updating a bookmark', () => {
       ({ _id }) => _id === owner.toString()
     );
     await login(user);
-    const title2 = 'Heyyo!';
 
     const response = await api
       .patch(`${url}/${_id}`)
       .set('Authorization', `Bearer ${token}`)
       .send({
-        title: title2,
         isRead: true,
       })
       .expect(200);
 
     expect(response.body.data).toHaveProperty('_id', _id.toString());
-    expect(response.body.data).toHaveProperty('title', title2);
     expect(response.body.data).toHaveProperty('isRead', true);
     expect(response.body.data.owner).toEqual(
       expect.objectContaining({
@@ -289,7 +279,6 @@ describe('Deleting a bookmark', () => {
     const user = helper.accountsAsJson.find(
       ({ _id }) => _id === owner.toString()
     );
-    console.log('🚀 ~ file: bookmarks.test.js:292 ~ user:', user);
     await login(user);
 
     await api

--- a/src/bookmarks/bookmarksController.js
+++ b/src/bookmarks/bookmarksController.js
@@ -41,7 +41,7 @@ const deleteBookmark = async (req, res) => {
 };
 
 const createBookmark = async (req, res) => {
-  const payload = { ...req.body };
+  const { postId, postType } = req.query;
   req.query.isPaginated = false;
   const { data: bookmarks } = await bookmarksService.getBookmarks(
     req.user._id,
@@ -49,7 +49,7 @@ const createBookmark = async (req, res) => {
   );
 
   const bookmarkExists = bookmarks.some(
-    (bookmark) => bookmark.post?._id.toString() === payload.postId
+    (bookmark) => bookmark.post?._id.toString() === postId
   );
 
   if (bookmarkExists) {
@@ -57,8 +57,9 @@ const createBookmark = async (req, res) => {
   }
 
   const newBookmark = await bookmarksService.createBookmark({
-    ...payload,
-    author: req.user._id,
+    post: postId,
+    postType,
+    owner: req.user._id,
   });
 
   new responseHandler(res, newBookmark, 201, RESPONSE_MESSAGE.SUCCESS);

--- a/src/bookmarks/bookmarksService.js
+++ b/src/bookmarks/bookmarksService.js
@@ -60,13 +60,8 @@ const getBookmark = async (bookmarkId) => {
   return bookmark;
 };
 
-const createBookmark = async ({ author, postId, postType, title }) => {
-  const newBookmark = await Bookmark.create({
-    title,
-    postType,
-    post: postId,
-    owner: author,
-  });
+const createBookmark = async (payload) => {
+  const newBookmark = await Bookmark.create(payload);
 
   await newBookmark.populate({
     path: 'owner',

--- a/src/bookmarks/bookmarksValidator.js
+++ b/src/bookmarks/bookmarksValidator.js
@@ -1,37 +1,23 @@
 const Joi = require('joi');
 const { POST_TYPES } = require('../../constant');
 
-const createBookmarkValidator = Joi.object({
-  postType: Joi.string()
-    .valid(...Object.values(POST_TYPES))
-    .required()
-    .messages({
-      'string.empty': 'Post Type is required',
-      'any.required': 'Post Type is required',
-    }),
-  postId: Joi.string().required().messages({
-    'string.empty': 'ID of post is required',
-    'any.required': 'ID of post is required',
-  }),
-  title: Joi.string().required().messages({
-    'string.empty': 'Title is required',
-    'any.required': 'Title is required',
-  }),
-});
-
-const updateBookmarkValidator = Joi.object({
-  title: Joi.string().optional(),
-  isRead: Joi.boolean().optional(),
-});
-
-const deleteBookmarkValidator = Joi.object({
-  bookmarkIds: Joi.array().items(Joi.string()).min(1).messages({
-    'array.min': 'bookmarkIds must be an array with at least one bookmark ID',
-    'array.base': 'bookmarkIds must be an array with at least one bookmark ID',
-  }),
-});
-
 class BookmarksValidator {
+  static validateCreateBookmark() {
+    return Joi.object({
+      postType: Joi.string()
+        .valid(...Object.values(POST_TYPES))
+        .required()
+        .messages({
+          'string.empty': 'Post Type is required',
+          'any.required': 'Post Type is required',
+        }),
+      postId: Joi.string().required().messages({
+        'string.empty': 'ID of post is required',
+        'any.required': 'ID of post is required',
+      }),
+    });
+  }
+
   static validateDeleteBookmark() {
     return Joi.object({
       postId: Joi.string().required().messages({
@@ -40,10 +26,23 @@ class BookmarksValidator {
       }),
     });
   }
+
+  static validateBulkDeleteBookmarks() {
+    return Joi.object({
+      bookmarkIds: Joi.array().items(Joi.string()).min(1).messages({
+        'array.min':
+          'bookmarkIds must be an array with at least one bookmark ID',
+        'array.base':
+          'bookmarkIds must be an array with at least one bookmark ID',
+      }),
+    });
+  }
+
+  static validateUpdateBookmarks() {
+    return Joi.object({
+      isRead: Joi.boolean().optional(),
+    });
+  }
 }
-module.exports = {
-  createBookmarkValidator,
-  deleteBookmarkValidator,
-  updateBookmarkValidator,
-  BookmarksValidator,
-};
+
+module.exports = { BookmarksValidator };

--- a/src/bookmarks/index.js
+++ b/src/bookmarks/index.js
@@ -16,7 +16,7 @@ router
   .get(validator.query(paginationSchema), bookmarks.getAllBookmarks)
   .post(
     limiter(),
-    validatorMiddleware(createBookmarkValidator),
+    validator.query(BookmarksValidator.validateCreateBookmark()),
     bookmarks.createBookmark
   )
   .delete(

--- a/src/bookmarks/index.js
+++ b/src/bookmarks/index.js
@@ -1,11 +1,7 @@
 const router = require('express').Router();
 const bookmarks = require('./bookmarksController');
 const { verifyUser } = require('../../middleware/authenticate');
-const {
-  createBookmarkValidator,
-  updateBookmarkValidator,
-  BookmarksValidator,
-} = require('./bookmarksValidator');
+const { BookmarksValidator } = require('./bookmarksValidator');
 const validatorMiddleware = require('../../middleware/validator');
 const { paginationSchema, validator } = require('../common');
 const limiter = require('../../middleware/rateLimit');
@@ -30,7 +26,7 @@ router
   .get(bookmarks.getBookmark)
   .patch(
     limiter(),
-    validatorMiddleware(updateBookmarkValidator),
+    validatorMiddleware(BookmarksValidator.validateUpdateBookmarks()),
     bookmarks.updateBookmark
   );
 

--- a/src/bookmarks/index.js
+++ b/src/bookmarks/index.js
@@ -22,6 +22,13 @@ router
   );
 
 router
+  .route('/bulk-delete')
+  .delete(
+    validatorMiddleware(BookmarksValidator.validateBulkDeleteBookmarks()),
+    bookmarks.deleteBookmarks
+  );
+
+router
   .route('/:id')
   .get(bookmarks.getBookmark)
   .patch(


### PR DESCRIPTION
This PR...

## Changes

- Bookmarks no longer have a title
- Bookmarks are created using query parameters i.e

`POST` `/bookmarks?postId=id-of-content-to-bookmark&postType=postType`
where postType is one of `'Answer'`,  `'Comment'`, `'Post'`, or `'Question'`

- To delete multiple bookmarks at a go, send a `DELETE` request to
`/bookmarks/bulk-delete`. It's payload is an object with a property of `bookmarkIds`. The value is an array with at least one `bookmarkId`  

```json
  {
    "bookmarkIds": ["bookmarkId1", "bookmarkId2", "bookmarkId3"]
  }
```

## Checklist

- [x] tested locally
- [ ] added new dependencies
- [ ] updated the Swagger API docs
- [x] updated the Postman collection
- [x] added a test
- [x] linter passes
- [x] format check passes

Fixes #227